### PR TITLE
Improve linkage to Confluent Cloud; update links to tryfree

### DIFF
--- a/c/README.md
+++ b/c/README.md
@@ -228,7 +228,7 @@ Depending on your available Kafka cluster, you have multiple options
 for creating a topic. You may have access to [Confluent Control
 Center](https://docs.confluent.io/platform/current/control-center/index.html),
 where you can [create a topic with a
-Console](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
+UI](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
 may have already installed a Kafka distribution, in which case you can
 use the [kafka-topics command](https://kafka.apache.org/documentation/#basic_ops_add_topic).
 Note that, if your cluster is centrally managed, you may need to

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -187,7 +187,7 @@ Depending on your available Kafka cluster, you have multiple options
 for creating a topic. You may have access to [Confluent Control
 Center](https://docs.confluent.io/platform/current/control-center/index.html),
 where you can [create a topic with a
-Console](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
+UI](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
 may have already installed a Kafka distribution, in which case you can
 use the [kafka-topics command](https://kafka.apache.org/documentation/#basic_ops_add_topic).
 Note that, if your cluster is centrally managed, you may need to

--- a/go/README.md
+++ b/go/README.md
@@ -167,7 +167,7 @@ Depending on your available Kafka cluster, you have multiple options
 for creating a topic. You may have access to [Confluent Control
 Center](https://docs.confluent.io/platform/current/control-center/index.html),
 where you can [create a topic with a
-Console](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
+UI](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
 may have already installed a Kafka distribution, in which case you can
 use the [kafka-topics command](https://kafka.apache.org/documentation/#basic_ops_add_topic).
 Note that, if your cluster is centrally managed, you may need to

--- a/java/README.md
+++ b/java/README.md
@@ -198,7 +198,7 @@ Depending on your available Kafka cluster, you have multiple options
 for creating a topic. You may have access to [Confluent Control
 Center](https://docs.confluent.io/platform/current/control-center/index.html),
 where you can [create a topic with a
-Console](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
+UI](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
 may have already installed a Kafka distribution, in which case you can
 use the [kafka-topics command](https://kafka.apache.org/documentation/#basic_ops_add_topic).
 Note that, if your cluster is centrally managed, you may need to

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -184,7 +184,7 @@ Depending on your available Kafka cluster, you have multiple options
 for creating a topic. You may have access to [Confluent Control
 Center](https://docs.confluent.io/platform/current/control-center/index.html),
 where you can [create a topic with a
-Console](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
+UI](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
 may have already installed a Kafka distribution, in which case you can
 use the [kafka-topics command](https://kafka.apache.org/documentation/#basic_ops_add_topic).
 Note that, if your cluster is centrally managed, you may need to

--- a/python/README.md
+++ b/python/README.md
@@ -214,7 +214,7 @@ Depending on your available Kafka cluster, you have multiple options
 for creating a topic. You may have access to [Confluent Control
 Center](https://docs.confluent.io/platform/current/control-center/index.html),
 where you can [create a topic with a
-Console](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
+UI](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
 may have already installed a Kafka distribution, in which case you can
 use the [kafka-topics command](https://kafka.apache.org/documentation/#basic_ops_add_topic).
 Note that, if your cluster is centrally managed, you may need to

--- a/rest/README.md
+++ b/rest/README.md
@@ -180,7 +180,7 @@ Depending on your available Kafka cluster, you have multiple options
 for creating a topic. You may have access to [Confluent Control
 Center](https://docs.confluent.io/platform/current/control-center/index.html),
 where you can [create a topic with a
-Console](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
+UI](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
 may have already installed a Kafka distribution, in which case you can
 use the [kafka-topics command](https://kafka.apache.org/documentation/#basic_ops_add_topic).
 Note that, if your cluster is centrally managed, you may need to

--- a/springboot/README.md
+++ b/springboot/README.md
@@ -204,7 +204,7 @@ Depending on your available Kafka cluster, you have multiple options
 for creating a topic. You may have access to [Confluent Control
 Center](https://docs.confluent.io/platform/current/control-center/index.html),
 where you can [create a topic with a
-Console](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
+UI](https://docs.confluent.io/platform/current/control-center/topics/create.html). You
 may have already installed a Kafka distribution, in which case you can
 use the [kafka-topics command](https://kafka.apache.org/documentation/#basic_ops_add_topic).
 Note that, if your cluster is centrally managed, you may need to


### PR DESCRIPTION
* Confluent Cloud UI --> Confluent Cloud Console
* https://www.confluent.io/confluent-cloud/tryfree/
* Move `docker compose` statement to later in tutorial where it is needed