### PR TITLE
Updated Confluent.Kafka to 1.9.3 (supports OIDC) and added sample OIDC config

### DIFF
--- a/dotnet/consumer/consumer.csproj
+++ b/dotnet/consumer/consumer.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.8.2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.9.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="6.0.0" />

--- a/dotnet/getting-started-cloud-oauth2.properties
+++ b/dotnet/getting-started-cloud-oauth2.properties
@@ -1,0 +1,9 @@
+bootstrap.servers={{ kafka.broker.server }}
+security.protocol=SASL_SSL
+sasl.mechanisms=OAUTHBEARER
+sasl.oauthbearer.method=OIDC
+sasl.oauthbearer.scope=< OAUTH2 SCOPE >
+sasl.oauthbearer.token.endpoint.url=https://< OAUTH2 SERVER >.okta.com/oauth2/default/v1/token
+sasl.oauthbearer.client.id=< CLIENT ID >
+sasl.oauthbearer.client.secret=< CLIENT SECRET >
+sasl.oauthbearer.extensions=logicalCluster=lkc-< LKC ID >,identityPoolId=pool-< POOL ID >

--- a/dotnet/producer/producer.csproj
+++ b/dotnet/producer/producer.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.8.2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.9.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="6.0.0" />


### PR DESCRIPTION
Updates the `Confluent.Kafka` package to current/latest `1.9.3`.

Added new sample properties `getting-started-cloud-oauth2.properties` which with the correct substitutions and a matching CCloud cluster config and OIDC/OAuth2 provider, allows the sample dotnet producer/consumer to work with OAuth2 authentication.