### PR TITLE
BACKLOG: Per user feedback change 'for run == true' to 'for run {' the run variable already set to true

### DIFF
--- a/go/consumer.go
+++ b/go/consumer.go
@@ -38,7 +38,7 @@ func main() {
 
     // Process messages
     run := true
-    for run == true {
+    for run {
         select {
         case sig := <-sigchan:
             fmt.Printf("Caught signal %v: terminating\n", sig)


### PR DESCRIPTION
Fix per user comment via feedback https://app.asana.com/0/1201906632362444/1203250531547947/f

Tested by running through the quickstart