### PR TITLE
chore: use plaintext formatting on `confluent local` and `brew install` code blocks

### DIFF
--- a/c/README.md
+++ b/c/README.md
@@ -153,7 +153,7 @@ First, install and start [Docker Desktop](https://docs.docker.com/desktop/) or [
 
 Install the Confluent CLI if you don't already have it. In your terminal:
 
-```sh
+```plaintext
 brew install confluentinc/tap/cli
 ```
 
@@ -163,7 +163,7 @@ This guide requires version 3.34.1 or later of the Confluent CLI. If you have an
 
 Now start the Kafka broker:
 
-```sh
+```plaintext
 confluent local kafka start
 ```
 
@@ -294,7 +294,7 @@ with 1 partition and defaults for the remaining settings.
 
 <section data-context-key="kafka.broker" data-context-value="local">
 
-```sh
+```plaintext
 confluent local kafka topic create purchases
 ```
 </section>
@@ -604,7 +604,7 @@ Once you are done with the consumer, enter `Ctrl-C` to terminate the consumer ap
 
 Shut down Kafka when you are done with it:
 
-```sh
+```plaintext
 confluent local kafka stop
 ```
 </section>

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -113,7 +113,7 @@ First, install and start [Docker Desktop](https://docs.docker.com/desktop/) or [
 
 Install the Confluent CLI if you don't already have it. In your terminal:
 
-```sh
+```plaintext
 brew install confluentinc/tap/cli
 ```
 
@@ -123,7 +123,7 @@ This guide requires version 3.34.1 or later of the Confluent CLI. If you have an
 
 Now start the Kafka broker:
 
-```sh
+```plaintext
 confluent local kafka start
 ```
 
@@ -254,7 +254,7 @@ with 1 partition and defaults for the remaining settings.
 
 <section data-context-key="kafka.broker" data-context-value="local">
 
-```sh
+```plaintext
 confluent local kafka topic create purchases
 ```
 </section>
@@ -360,7 +360,7 @@ Once you are done with the consumer, enter `Ctrl-C` to terminate the consumer ap
 
 Shut down Kafka when you are done with it:
 
-```sh
+```plaintext
 confluent local kafka stop
 ```
 </section>

--- a/go/README.md
+++ b/go/README.md
@@ -110,7 +110,7 @@ First, install and start [Docker Desktop](https://docs.docker.com/desktop/) or [
 
 Install the Confluent CLI if you don't already have it. In your terminal:
 
-```sh
+```plaintext
 brew install confluentinc/tap/cli
 ```
 
@@ -120,7 +120,7 @@ This guide requires version 3.34.1 or later of the Confluent CLI. If you have an
 
 Now start the Kafka broker:
 
-```sh
+```plaintext
 confluent local kafka start
 ```
 
@@ -252,7 +252,7 @@ with 1 partition and defaults for the remaining settings.
 
 <section data-context-key="kafka.broker" data-context-value="local">
 
-```sh
+```plaintext
 confluent local kafka topic create purchases
 ```
 </section>
@@ -352,7 +352,7 @@ Once you are done with the consumer, enter `Ctrl-C` to terminate the consumer ap
 
 Shut down Kafka when you are done with it:
 
-```sh
+```plaintext
 confluent local kafka stop
 ```
 </section>

--- a/java/README.md
+++ b/java/README.md
@@ -114,7 +114,7 @@ First, install and start [Docker Desktop](https://docs.docker.com/desktop/) or [
 
 Install the Confluent CLI if you don't already have it. In your terminal:
 
-```sh
+```plaintext
 brew install confluentinc/tap/cli
 ```
 
@@ -124,7 +124,7 @@ This guide requires version 3.34.1 or later of the Confluent CLI. If you have an
 
 Now start the Kafka broker:
 
-```sh
+```plaintext
 confluent local kafka start
 ```
 
@@ -256,7 +256,7 @@ with 1 partition and defaults for the remaining settings.
 
 <section data-context-key="kafka.broker" data-context-value="local">
 
-```sh
+```plaintext
 confluent local kafka topic create purchases
 ```
 </section>
@@ -390,7 +390,7 @@ Once you are done with the consumer, enter `Ctrl-C` to terminate the consumer ap
 
 Shut down Kafka when you are done with it:
 
-```sh
+```plaintext
 confluent local kafka stop
 ```
 </section>

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -114,7 +114,7 @@ First, install and start [Docker Desktop](https://docs.docker.com/desktop/) or [
 
 Install the Confluent CLI if you don't already have it. In your terminal:
 
-```sh
+```plaintext
 brew install confluentinc/tap/cli
 ```
 
@@ -124,7 +124,7 @@ This guide requires version 3.34.1 or later of the Confluent CLI. If you have an
 
 Now start the Kafka broker:
 
-```sh
+```plaintext
 confluent local kafka start
 ```
 
@@ -255,7 +255,7 @@ with 1 partition and defaults for the remaining settings.
 
 <section data-context-key="kafka.broker" data-context-value="local">
 
-```sh
+```plaintext
 confluent local kafka topic create purchases
 ```
 </section>
@@ -347,7 +347,7 @@ Once you are done with the consumer, enter `Ctrl-C` to terminate the consumer ap
 
 Shut down Kafka when you are done with it:
 
-```sh
+```plaintext
 confluent local kafka stop
 ```
 </section>

--- a/python/README.md
+++ b/python/README.md
@@ -136,7 +136,7 @@ First, install and start [Docker Desktop](https://docs.docker.com/desktop/) or [
 
 Install the Confluent CLI if you don't already have it. In your terminal:
 
-```sh
+```plaintext
 brew install confluentinc/tap/cli
 ```
 
@@ -146,7 +146,7 @@ This guide requires version 3.34.1 or later of the Confluent CLI. If you have an
 
 Now start the Kafka broker:
 
-```sh
+```plaintext
 confluent local kafka start
 ```
 
@@ -277,7 +277,7 @@ with 1 partition and defaults for the remaining settings.
 
 <section data-context-key="kafka.broker" data-context-value="local">
 
-```sh
+```plaintext
 confluent local kafka topic create purchases
 ```
 </section>
@@ -371,7 +371,7 @@ Once you are done with the consumer, enter `Ctrl-C` to terminate the consumer ap
 
 Shut down Kafka when you are done with it:
 
-```sh
+```plaintext
 confluent local kafka stop
 ```
 </section>

--- a/rest/README.md
+++ b/rest/README.md
@@ -103,7 +103,7 @@ First, install and start [Docker Desktop](https://docs.docker.com/desktop/) or [
 
 Install the Confluent CLI if you don't already have it. In your terminal:
 
-```sh
+```plaintext
 brew install confluentinc/tap/cli
 ```
 
@@ -113,7 +113,7 @@ This guide requires version 3.34.1 or later of the Confluent CLI. If you have an
 
 Now start the Kafka broker:
 
-```sh
+```plaintext
 confluent local kafka start
 ```
 
@@ -243,7 +243,7 @@ with 1 partition and defaults for the remaining settings.
 
 <section data-context-key="kafka.broker" data-context-value="local">
 
-```sh
+```plaintext
 confluent local kafka topic create purchases
 ```
 </section>
@@ -464,7 +464,7 @@ curl -X DELETE \
 
 Shut down Kafka when you are done with it:
 
-```sh
+```plaintext
 confluent local kafka stop
 ```
 </section>

--- a/spring-boot/README.md
+++ b/spring-boot/README.md
@@ -115,7 +115,7 @@ First, install and start [Docker Desktop](https://docs.docker.com/desktop/) or [
 
 Install the Confluent CLI if you don't already have it. In your terminal:
 
-```sh
+```plaintext
 brew install confluentinc/tap/cli
 ```
 
@@ -125,7 +125,7 @@ This guide requires version 3.34.1 or later of the Confluent CLI. If you have an
 
 Now start the Kafka broker:
 
-```sh
+```plaintext
 confluent local kafka start
 ```
 
@@ -274,7 +274,7 @@ with 1 partition and defaults for the remaining settings.
 
 <section data-context-key="kafka.broker" data-context-value="local">
 
-```sh
+```plaintext
 confluent local kafka topic create purchases
 ```
 </section>
@@ -398,7 +398,7 @@ Once you are done with the consumer, enter `Ctrl-C` to terminate the consumer ap
 
 Shut down Kafka when you are done with it:
 
-```sh
+```plaintext
 confluent local kafka stop
 ```
 </section>


### PR DESCRIPTION
`sh` formatting causes `local` and `install` to be highlighted since they are shell commands. Arguably this is a hljs shortcoming since we'd only want these keywords highlighted if appearing as the top level command, not an argument of another command.