### PR TITLE
use correct framework

### DIFF
--- a/dotnet/consumer/consumer.csproj
+++ b/dotnet/consumer/consumer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <StartupObject>Consumer</StartupObject>
   </PropertyGroup>
 

--- a/dotnet/producer/producer.csproj
+++ b/dotnet/producer/producer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <StartupObject>Producer</StartupObject>
   </PropertyGroup>
 


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)