### PR TITLE
dotnet typo: add commas

### DIFF
--- a/dotnet/consumer/consumer_cloud_basic.cs
+++ b/dotnet/consumer/consumer_cloud_basic.cs
@@ -11,11 +11,11 @@ class Consumer {
             // User-specific properties that you must set
             BootstrapServers = "<BOOTSTRAP SERVERS>",
             SaslUsername     = "<CLUSTER API KEY>",
-            SaslPassword     = "<CLUSTER API SECRET>"
+            SaslPassword     = "<CLUSTER API SECRET>",
 
             // Fixed properties
-            SecurityProtocol = SecurityProtocol.SaslSsl
-            SaslMechanism    = SaslMechanism.Plain
+            SecurityProtocol = SecurityProtocol.SaslSsl,
+            SaslMechanism    = SaslMechanism.Plain,
             GroupId          = "kafka-dotnet-getting-started",
             AutoOffsetReset  = AutoOffsetReset.Earliest
         };

--- a/dotnet/producer/producer_cloud_basic.cs
+++ b/dotnet/producer/producer_cloud_basic.cs
@@ -14,11 +14,11 @@ class Producer {
             // User-specific properties that you must set
             BootstrapServers = "<BOOTSTRAP SERVERS>",
             SaslUsername     = "<CLUSTER API KEY>",
-            SaslPassword     = "<CLUSTER API SECRET>"
+            SaslPassword     = "<CLUSTER API SECRET>",
 
             // Fixed properties
-            SecurityProtocol = SecurityProtocol.SaslSsl
-            SaslMechanism    = SaslMechanism.Plain
+            SecurityProtocol = SecurityProtocol.SaslSsl,
+            SaslMechanism    = SaslMechanism.Plain,
             Acks             = Acks.All
         };
 


### PR DESCRIPTION
some commas missing in the dotnet guide that caused errors on build. 

(ironically there is a typo in the branch name :P )