### PR TITLE
in Python example, poll in producer loop with zero timeout

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -48,7 +48,7 @@ Install the Apache Kafka Python client library:
 pip install confluent-kafka
 ```
 
-Note: this guide was last tested using version `2.4.0` of the client.
+Note: this guide was last tested using version `2.12.1` of the client.
 
 ## Kafka Setup
 

--- a/python/producer_cloud_basic.py
+++ b/python/producer_cloud_basic.py
@@ -42,6 +42,8 @@ if __name__ == '__main__':
         producer.produce(topic, product, user_id, callback=delivery_callback)
         count += 1
 
-    # Block until the messages are sent.
-    producer.poll(10000)
+        # Trigger any outstanding delivery report callbacks.
+        producer.poll(0)
+
+    # Block until the messages are delivered.
     producer.flush()

--- a/python/producer_cloud_oauth.py
+++ b/python/producer_cloud_oauth.py
@@ -46,6 +46,8 @@ if __name__ == '__main__':
         producer.produce(topic, product, user_id, callback=delivery_callback)
         count += 1
 
-    # Block until the messages are sent.
-    producer.poll(10000)
+        # Trigger any outstanding delivery report callbacks.
+        producer.poll(0)
+
+    # Block until the messages are delivered.
     producer.flush()

--- a/python/producer_existing.py
+++ b/python/producer_existing.py
@@ -38,6 +38,8 @@ if __name__ == '__main__':
         producer.produce(topic, product, user_id, callback=delivery_callback)
         count += 1
 
-    # Block until the messages are sent.
-    producer.poll(10000)
+        # Trigger any outstanding delivery report callbacks.
+        producer.poll(0)
+
+    # Block until the messages are delivered.
     producer.flush()

--- a/python/producer_local.py
+++ b/python/producer_local.py
@@ -38,6 +38,8 @@ if __name__ == '__main__':
         producer.produce(topic, product, user_id, callback=delivery_callback)
         count += 1
 
-    # Block until the messages are sent.
-    producer.poll(10000)
+        # Trigger any outstanding delivery report callbacks.
+        producer.poll(0)
+
+    # Block until the messages are delivered.
     producer.flush()


### PR DESCRIPTION
The previous poll wait wasn't necessary because flush blocks until all delivery reports are triggered.